### PR TITLE
Retrieve_categories | Fixed code | Review to test proper functionality

### DIFF
--- a/views/category_view.py
+++ b/views/category_view.py
@@ -93,29 +93,26 @@ def retrieve_categories(pk, expand=False):
         query_results = db_cursor.fetchone()
 
         if not query_results:
-            return None  # Return None if ship is not found
+            return None  # Return None if category is not found
 
         # Convert the sqlite3.Row object to a dictionary
         query_results_dict = dict(query_results)
 
-        # Build the ship dictionary
-        category_id = query_results_dict.get("categoryId")
-        category_label = query_results_dict.get("categoryLabel")
-        
         category = {
             "id": query_results_dict["id"],
             "label": query_results_dict["label"],
-            "category_id": query_results_dict["category_id"],
-            "category": (
-                {
-                    "id": category_id,
-                    "label": category_label
-                }
-                if all(val is not None for val in [category_id, category_label])
-                and expand
-                else None
-            ),
         }
+
+        if expand:
+            category["category_id"] = query_results_dict.get("category_id")
+            category["category"] = (
+                {
+                    "id": query_results_dict.get("category_id"),
+                    "label": query_results_dict.get("category_label"),
+                }
+                if expand
+                else None
+            )
         # Serialize Python list to JSON encoded string
 
         serialized_category = json.dumps(category)


### PR DESCRIPTION
changes made:
--- Fixed the code for retrieve_categories in category_view.py so user can retrieve categories by category id (start at line 62)

why changes were necessary:
--- initially retrieve_categories was not pulling a category when user made the attempt in Postman 

specific things to look for during review:
--- In Postman, use GET method and select a category id to retrieve (ex: http://localhost:8000/categories/1)
--- Your result should show both the id and the label for the category requested and the id shown should match the id that you use for the GET request. Your Postman output should look similar to this:
{
    "id": 1
    "label": "News"
}


Related Ticket(s): https://github.com/NSS-Day-Cohort-68/rare-client-rare-team-4/issues/42