### PR TITLE
New users no longer need to specify unnecessary parameters

### DIFF
--- a/views/user.py
+++ b/views/user.py
@@ -63,10 +63,10 @@ def create_user(user):
                 user["last_name"],
                 user["username"],
                 user["email"],
-                user["password"],
-                user["bio"],
+                user.get("password", None),
+                user.get("bio", None),
                 datetime.now(),
-                user.get("profile_image_url", ""),
+                user.get("profile_image_url", None),
                 user.get("active", 1),
             ),
         )
@@ -151,7 +151,7 @@ def get_all_users():
 
 
 def create_tag(tag):
-    print("Tag received:", tag)  # Print statement to see the content of the tag
+    # print("Tag received:", tag)  # Print statement to see the content of the tag
     with sqlite3.connect(database) as conn:
         conn.row_factory = dict_factory
         db_cursor = conn.cursor()


### PR DESCRIPTION
Testing info:
- Making a POST request to `/users` should no longer throw an error as long as `first_name`, `last_name`, `username`, and `email` are provided.

Ticket #47 | https://github.com/NSS-Day-Cohort-68/rare-client-rare-team-4/issues/47