### PR TITLE
getting comments

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -118,3 +118,4 @@ INSERT INTO Users (first_name, last_name, email, bio, username, password, profil
 VALUES ('Alice', 'Smith', 'alice.smith@example.com', 'Product Manager', 'alicesmith', 'password789', 'https://example.com/alicesmith.jpg', '2023-04-03', 1);
 
 
+INSERT INTO Comments (post_id, author_id, content) VALUES (1, 1, "I love cats!");

--- a/server.py
+++ b/server.py
@@ -14,6 +14,8 @@ from views import (
     get_all_posts,
     create_tag,
     get_user_by_email,
+    get_comments,
+    get_single_comment,
 )
 
 from helper import has_unsupported_params, missing_fields
@@ -75,10 +77,12 @@ class JSONServer(HandleRequests):
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
         # comments:
         elif url["requested_resource"] == "comments":
-            # TODO: handle GET comments
-            return self.response(
-                "Feature is not yet implemented.", status.HTTP_501_NOT_IMPLEMENTED.value
-            )  #!
+            if url["pk"] != 0:
+                response_body = get_single_comment(url["pk"])
+                return self.response(response_body, status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
+            response_body = get_comments()
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
         # categories:
         elif url["requested_resource"] == "categories":
             if url["pk"] != 0:

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -5,6 +5,8 @@ from .user import (
     get_all_users,
     create_tag,
     get_user_by_email,
+    
 )
 from .category_view import create_category, list_categories, retrieve_categories
 from .post import get_all_posts, specific_post
+from .comments import get_comments, get_single_comment

--- a/views/comments.py
+++ b/views/comments.py
@@ -1,0 +1,55 @@
+import sqlite3
+import json
+from .views_helper import dict_factory
+
+database = "./db.sqlite3"
+
+def get_comments():
+
+    with sqlite3.connect(database) as conn:
+        conn.row_factory = dict_factory
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            SELECT *
+            FROM Comments
+        """
+        )
+
+        query_results = db_cursor.fetchall()
+
+        comments = []
+
+        for row in query_results:
+            comment = {
+                "id": row['id'],
+                "post_id": row['post_id'],
+                "author_id": row['author_id'],
+                "content": row['content']
+            }
+            comments.append(comment)
+        serialized_comments = json.dumps(comments)
+    return serialized_comments
+
+
+def get_single_comment(pk):
+    with sqlite3.connect(database) as conn:
+        conn.row_factory = dict_factory
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+        """
+            SELECT
+                c.id,
+                c.post_id,
+                c.author_id,
+                c.content
+            FROM Comments c
+            WHERE c.id = ?
+        """,(pk,))
+        query_results = db_cursor.fetchone()
+
+        dictionary_version_of_object = dict(query_results)
+        serialized_comment = json.dumps(dictionary_version_of_object)
+    return serialized_comment


### PR DESCRIPTION
Adding functionality to get comments from sql database. It contains code for selecting both all the comments and comments by id number.

These changes will allow comments to be called on the client side. 

This includes both the definition of the "GET" method, and then calling it in the server.

You can test it by running the server, then going to http://localhost:8000/comments to pull all of them (which currently there is just one), and if you do http://localhost:8000/comments/1 you should also see the same comment. 

