### PR TITLE
Added functionality for deleting categories

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -107,7 +107,6 @@ SELECT * FROM Tags;
 SELECT * FROM PostTags;
 SELECT * FROM Categories;
 
-
 --? TEST DATA ?--
 -- test users
 INSERT INTO Users (first_name, last_name, email, bio, username, password, profile_image_url, created_on, active)

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -131,10 +131,3 @@ VALUES (2, 1, 'Second Example Post', '2023-04-02 00:00:00', null, 'Lorem ipsum d
 
 INSERT INTO Posts (user_id, category_id, title, publication_date, image_url, content, approved)
 VALUES (3, 1, 'Third Example Post', '2023-04-03 00:00:00', 'https://www.pixelstalk.net/wp-content/uploads/2016/07/Wallpapers-pexels-photo.jpg', 'Lorem ipsum dolor sit amet consectetur adipiscing elit leo, et inceptos eget mus cum rutrum potenti, praesent libero tortor morbi condimentum tempor ullamcorper. Placerat semper facilisi netus nascetur tellus sapien habitasse magna natoque, sodales odio arcu velit hac elementum porttitor mattis magnis, mi gravida viverra quis per mollis nullam luctus. Faucibus massa erat posuere quisque varius ornare lobortis nisi, nunc vivamus penatibus sollicitudin sociosqu pellentesque ligula felis, dapibus conubia purus justo torquent egestas convallis. Imperdiet nibh nostra integer molestie feugiat duis diam accumsan phasellus ante class, auctor ad rhoncus nam bibendum orci donec facilisis urna pulvinar. Eleifend dis fermentum parturient pretium vestibulum augue euismod nec, consequat vulputate habitant eu curae suscipit vitae venenatis, eros risus at sagittis ridiculus congue himenaeos.', 1);
-
-
--- test posts
-
-INSERT INTO Posts (user_id, category_id, title, publication_date, image_url, content, approved) VALUES (1, 1, 'stuff that is really true', '2023-04-02', 'na','ipsum ipsm fat cat is loud', 'True'); 
-
-UPDATE Posts SET publication_date = "2022-03-08" WHERE id = 1;

--- a/request_handler.py
+++ b/request_handler.py
@@ -17,6 +17,7 @@ class status(Enum):
     HTTP_411_LENGTH_REQUIRED = 411
     HTTP_412_PRECONDITION_FAILED = 412
     HTTP_501_NOT_IMPLEMENTED = 501
+    HTTP_403_FORBIDDEN = 403
 
 
 class HandleRequests(BaseHTTPRequestHandler):

--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ from views import (
     get_tag,
     get_all_tags,
     add_comment,
+    delete_category,
 )
 
 from helper import has_unsupported_params, missing_fields
@@ -273,10 +274,29 @@ class JSONServer(HandleRequests):
     def do_DELETE(self):
         """handle DELETE requests from a client"""
 
-        # TODO: handle DELETE requests
-        return self.response(
-            "Feature is not yet implemented.", status.HTTP_501_NOT_IMPLEMENTED.value
-        )  #!
+        url = self.parse_url(self.path)
+        pk = url["pk"]
+
+        if url["requested_resource"] == "categories":
+            if pk != 0:
+                deleted = delete_category(pk)
+                if deleted:
+                    return self.response(
+                        "", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value
+                    )
+
+                return self.response(
+                    "Requested resource not found",
+                    status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+                )
+            else:
+                return self.response("", status.HTTP_403_FORBIDDEN.value)
+
+        else:
+            # invalid request
+            return self.response(
+                "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
+            )
 
 
 def main():

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -6,7 +6,12 @@ from .user import (
     create_tag,
     get_user_by_email,
 )
-from .category import create_category, list_categories, retrieve_categories
+from .category import (
+    create_category,
+    list_categories,
+    retrieve_categories,
+    delete_category,
+)
 from .post import get_all_posts, specific_post
 from .tag import get_tag, get_all_tags
 from .comment import get_comments, get_single_comment, add_comment

--- a/views/category.py
+++ b/views/category.py
@@ -17,7 +17,7 @@ def create_category(category_data):
             INSERT INTO Categories (label)
             VALUES (?)
             """,
-            (category_data["label"],)
+            (category_data["label"],),
         )
 
         # Get the last inserted row id to confirm the creation
@@ -34,23 +34,20 @@ def list_categories(url):
         db_cursor = conn.cursor()
 
         db_cursor.execute(
-                """
+            """
             SELECT
                 c.id,
                 c.label
             FROM Categories c              
             """
-            )
+        )
         query_results = db_cursor.fetchall()
 
         # Initialize an empty list and then add each dictionary to it
 
         categories = []
         for row in query_results:
-            category = {
-                "id": row['id'],
-                "label": row['label']
-            }
+            category = {"id": row["id"], "label": row["label"]}
             categories.append(category)
 
         # Serialize Python list to JSON encoded string
@@ -118,3 +115,19 @@ def retrieve_categories(pk, expand=False):
         serialized_category = json.dumps(category)
 
     return serialized_category
+
+
+def delete_category(pk):
+    with sqlite3.connect(database) as conn:
+        conn.row_factory = dict_factory
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            DELETE FROM Categories
+            WHERE id = ?
+            """,
+            (pk,),
+        )
+
+    return True if db_cursor.rowcount > 0 else False


### PR DESCRIPTION
This pull request adds the functionality to delete categories from the database.

Testing info:
- Making a DELETE request in Postman at `/categories/n` (where `n` is equal to the category's `id`) should return:
`204 No Content` - If the category existed, and was deleted.
- Making a DELETE request in Postman at `/categories/n` (where `n` is equal to the category's `id`) should return:
`404 Not Found - Requested resource not found` - If the category did not exist.
- Making a GET request in Postman at `/categories` should show that deleted categories no longer exist.

Ticket [#32](https://github.com/NSS-Day-Cohort-68/rare-client-rare-team-4/issues/32)