### PR TITLE
Fixed delete category success response.

### DIFF
--- a/server.py
+++ b/server.py
@@ -281,9 +281,7 @@ class JSONServer(HandleRequests):
             if pk != 0:
                 deleted = delete_category(pk)
                 if deleted:
-                    return self.response(
-                        "", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value
-                    )
+                    return self.response("{}", status.HTTP_200_SUCCESS.value)
 
                 return self.response(
                     "Requested resource not found",


### PR DESCRIPTION
This pull request fixes the response from the server when deleting a category to prevent an error from being thrown on the client-side.

Testing info:
- Making a _successful_ DELETE request in Postman at `/categories/n` (where `n` is equal to the category's `id`) should now return `200 OK`, with an empty object (`{}`).


Ticket [#32](https://github.com/NSS-Day-Cohort-68/rare-client-rare-team-4/issues/32)