### PR TITLE
added expand info for comments api

### DIFF
--- a/views/comment.py
+++ b/views/comment.py
@@ -24,10 +24,19 @@ def get_comments():
                 u.last_name,
                 u.username,
                 u.email,
-                u.id AS user_id
+                u.id AS user_id,
+                p.id AS post_number,
+                p.title,
+                p.image_url,
+                p.publication_date,
+                p.content AS post_content,
+                p.approved,
+                p.category_id
             FROM Comments C
             JOIN Users u
                 on u.id = c.author_id
+            JOIN Posts p
+                on p.id = c.post_id
         """
         )
 
@@ -36,6 +45,16 @@ def get_comments():
         comments = []
 
         for row in query_results:
+            post = {
+                "id": row["post_number"],
+                "title": ["title"],
+                "image_url": row["image_url"],
+                "publication_date": row["publication_date"],
+                "content": row["content"],
+                "approved": row["approved"],
+                "user_id": row["user_id"],
+                "category_id": row["category_id"],
+            }
             user = {
                 "id": row["user_id"],
                 "first_name": row["first_name"],
@@ -50,6 +69,7 @@ def get_comments():
                 "content": row["content"],
                 "date": row["date"],
                 "user": user,
+                "post": post,
             }
             comments.append(comment)
         serialized_comments = json.dumps(comments)


### PR DESCRIPTION
The view comments ticket on client side needed an expanded comment table to view the post's title.

Added the sql join to the get_comments function to join the comments and posts tables. 

This will help the client side know the title of the comments being viewed


With API running, got to postman and run the get method with http://localhost:8000/comments as your url. You will see both expanded info for the user and the post