### PR TITLE
Fixed Implementation of Tag Deletion

### DIFF
--- a/server.py
+++ b/server.py
@@ -364,8 +364,16 @@ class JSONServer(HandleRequests):
                     return self.response("{}", status.HTTP_200_SUCCESS.value)
 
                 return self.response(
-                    "Requested resource not found",
-                    status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+                    "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
+                )
+
+            elif url["requested_resource"] == "tags":
+                deleted = delete_tag(pk)
+                if deleted:
+                    return self.response("{}", status.HTTP_200_SUCCESS.value)
+
+                return self.response(
+                    "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                 )
 
             elif url["requested_resource"] == "posts":
@@ -375,17 +383,16 @@ class JSONServer(HandleRequests):
                         return self.response("{}", status.HTTP_200_SUCCESS.value)
 
                     return self.response(
-                        "Resource not found",
-                        status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+                        "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
             else:
-                return self.response("", status.HTTP_403_FORBIDDEN.value)
+                return self.response(
+                    "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
+                )
 
         else:
             # invalid request
-            return self.response(
-                "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
-            )
+            return self.response("", status.HTTP_403_FORBIDDEN.value)
 
 
 def main():


### PR DESCRIPTION
This pull request fixes the functionality to delete tags from the database.

Testing info:
- Making a DELETE request in Postman at `/tags/n` (where `n` is equal to the tag's `id`), _and the tag existed and was deleted_, should return: `200 OK` - `{}` 
- Making a DELETE request in Postman at `/tags/n` (where `n` is equal to the tag's `id`), _and the tag did not exist_, should return: `404 Not Found`
- Making a GET request in Postman at `/tags` should show that the deleted tags no longer exist.

Ticket [#30](https://github.com/NSS-Day-Cohort-68/rare-client-rare-team-4/issues/30)